### PR TITLE
patch: changed return output to work with API

### DIFF
--- a/man/get_shortest_path.Rd
+++ b/man/get_shortest_path.Rd
@@ -7,7 +7,7 @@
 get_shortest_path(
   start_id,
   end_id,
-  gpkg,
+  gpkg = NULL,
   filename = NULL,
   lyrs = c("divides", "flowpaths", "network", "nexus", "flowpath-attributes")
 )


### PR DESCRIPTION
# Patched:
- changed the output of `get_shortest_path.R` to return an object rather than creating a file and returning nothing

### Example:
``` R
> library(hfsubsetR)
> 
> hfsubsetR::get_shortest_path(
+     start_id = 4699143,
+     end_id = 4700053,
+     gpkg = "~/hydrofabric/v2.2/conus_nextgen.gpkg",
+ )


$flowpaths
Simple feature collection with 3 features and 12 fields
Geometry type: LINESTRING
Dimension:     XY
Bounding box:  xmin: 1508780 ymin: 2069450 xmax: 1520174 ymax: 2076095
Projected CRS: NAD83 / Conus Albers
# A tibble: 3 × 13
  id       toid    mainstem order hydroseq lengthkm areasqkm
  <chr>    <chr>      <dbl> <dbl>    <int>    <dbl>    <dbl>
1 wb-87650 nex-87…    74074     1    26925     7.30    14.7 
2 wb-87403 nex-87…    73039     6    26924     5.28    13.7 
3 wb-87404 nex-87…    73039     6    26915     6.87     7.83
# ℹ 6 more variables: tot_drainage_areasqkm <dbl>,
#   has_divide <lgl>, divide_id <chr>, poi_id <chr>,
#   vpuid <chr>, geom <LINESTRING [m]>

$divides
Simple feature collection with 3 features and 10 fields
Geometry type: POLYGON
Dimension:     XY
Bounding box:  xmin: 1507875 ymin: 2067075 xmax: 1520415 ymax: 2077875
Projected CRS: NAD83 / Conus Albers
# A tibble: 3 × 11
  divide_id toid   type  ds_id areasqkm vpuid id    lengthkm
  <chr>     <chr>  <chr> <dbl>    <dbl> <chr> <chr>    <dbl>
1 cat-87404 nex-8… netw…    NA     7.83 02    wb-8…     6.87
2 cat-87650 nex-8… netw…    NA    14.7  02    wb-8…     7.30
3 cat-87403 nex-8… netw…    NA    13.7  02    wb-8…     5.28
# ℹ 3 more variables: tot_drainage_areasqkm <dbl>,
#   has_flowline <lgl>, geom <POLYGON [m]>

$nexus
Simple feature collection with 3 features and 5 fields
Geometry type: POINT
Dimension:     XY
Bounding box:  xmin: 1510843 ymin: 2073575 xmax: 1520174 ymax: 2075892
Projected CRS: NAD83 / Conus Albers
# A tibble: 3 × 6
  id      toid  type  vpuid poi_id              geom
  <chr>   <chr> <chr> <chr> <chr>        <POINT [m]>
1 nex-87… wb-8… nexus 02    NA     (1510843 2075122)
2 nex-87… wb-8… nexus 02    11652  (1515701 2075892)
3 nex-87… wb-8… nexus 02    43349  (1520174 2073575)

$network
# A tibble: 26 × 19
   id      toid  divide_id ds_id mainstem hydroseq hf_source
   <chr>   <chr> <chr>     <dbl>    <dbl>    <int> <chr>    
 1 wb-876… nex-… cat-87647    NA    74069    27606 NOAA Ref…
 2 wb-876… nex-… cat-87647    NA    74069    27606 NOAA Ref…
 3 wb-876… nex-… cat-87647    NA    74069    27606 NOAA Ref…
 4 wb-876… nex-… cat-87647    NA    74069    27606 NOAA Ref…
 5 wb-874… nex-… cat-87402    NA    73039    26931 NOAA Ref…
 6 wb-874… nex-… cat-87402    NA    73039    26931 NOAA Ref…
 7 wb-874… nex-… cat-87402    NA    73039    26931 NOAA Ref…
 8 wb-874… nex-… cat-87403    NA    73039    26924 NOAA Ref…
 9 wb-876… nex-… cat-87646    NA    74066    26923 NOAA Ref…
10 wb-876… nex-… cat-87646    NA    74066    26923 NOAA Ref…
# ℹ 16 more rows
# ℹ 12 more variables: hf_id <dbl>, lengthkm <dbl>,
#   areasqkm <dbl>, tot_drainage_areasqkm <dbl>,
#   type <chr>, vpuid <chr>, hf_hydroseq <dbl>,
#   hf_lengthkm <dbl>, hf_mainstem <dbl>, topo <chr>,
#   poi_id <chr>, hl_uri <chr>
# ℹ Use `print(n = ...)` to see more rows

$`flowpath-attributes`
# A tibble: 3 × 21
  link     to     Length_m     Y     n   nCC BtmWdth TopWdth
  <chr>    <chr>     <dbl> <dbl> <dbl> <dbl>   <dbl>   <dbl>
1 wb-87650 nex-8…    7297. 0.568  0.06  0.12    8.14    9.13
2 wb-87403 nex-8…    5278. 1.63   0.05  0.1    41.3    45.0 
3 wb-87404 nex-8…    6874. 1.64   0.05  0.1    41.5    45.2 
# ℹ 13 more variables: TopWdthCC <dbl>, ChSlp <dbl>,
#   alt <dbl>, So <dbl>, MusX <dbl>, MusK <dbl>,
#   gage <chr>, gage_nex_id <chr>, WaterbodyID <chr>,
#   waterbody_nex_id <chr>, id <chr>, toid <chr>,
#   vpuid <chr>
```